### PR TITLE
Issue 11: add AMP plugin dependency notice and logic

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -167,3 +167,8 @@ require get_template_directory() . '/inc/customizer.php';
 if ( defined( 'JETPACK__VERSION' ) ) {
 	require get_template_directory() . '/inc/jetpack.php';
 }
+
+/**
+ * AMP plugin dependency.
+ */
+require get_template_directory() . '/inc/plugin-dependency.php';

--- a/inc/plugin-dependency.php
+++ b/inc/plugin-dependency.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * AMP plugin dependency.
+ *
+ * @since 0.1
+ * @package AMPConf
+ */
+
+/**
+ * AMP Plugin dependency notice.
+ *
+ * @since 0.1
+ */
+function ampconf_plugin_dependency_notice() {
+	$filepath = 'amp/amp.php';
+	$updates  = get_site_transient( 'update_plugins' );
+
+	// Don't display notice on the installer screen.
+	if ( 'update' === get_current_screen()->base ) {
+		return;
+	}
+
+	if ( ! array_key_exists( $filepath, get_plugins() ) ) {
+		$slug    = 'amp';
+		$path    = 'update.php';
+		$button  = __( 'Install', 'ampconf' );
+		$message = __( 'The AMPConf theme requires the AMP plugin to be installed to function properly.', 'ampconf' );
+		$params  = array(
+			'action'   => 'install-plugin',
+			'plugin'   => $slug,
+			'_wpnonce' => wp_create_nonce( "install-plugin_{$slug}" ),
+		);
+	} elseif ( ! is_plugin_active( $filepath ) ) {
+		$path    = 'plugins.php';
+		$button  = __( 'Activate', 'ampconf' );
+		$message = __( 'The AMPConf theme requires the AMP plugin to be activated to function properly.', 'ampconf' );
+		$params  = array(
+			'action'   => 'activate',
+			'plugin'   => $filepath,
+			'_wpnonce' => wp_create_nonce( "activate-plugin_{$filepath}" ),
+		);
+	} elseif ( isset( $updates->response[ $filepath ]->new_version ) ) {
+		$path    = 'update.php';
+		$button  = __( 'Update', 'ampconf' );
+		$message = __( 'A new version of the AMP plugin is available, please upgrade.', 'ampconf' );
+		$params  = array(
+			'action'   => 'upgrade-plugin',
+			'plugin'   => $filepath,
+			'_wpnonce' => wp_create_nonce( "upgrade-plugin_{$filepath}" ),
+		);
+	}
+
+	if ( isset( $message ) ) {
+		?>
+		<div class="notice notice-warning">
+			<p><?php echo esc_html( $message ); ?></p>
+			<p>
+				<a href="<?php echo esc_url( add_query_arg( $params, self_admin_url( $path ) ) ); ?>" class="button button-primary"><?php echo esc_html( $button ); ?></a>
+			</p>
+		</div>
+		<?php
+	}
+}
+add_action( 'admin_notices', 'ampconf_plugin_dependency_notice' );

--- a/inc/plugin-dependency.php
+++ b/inc/plugin-dependency.php
@@ -23,7 +23,7 @@ function ampconf_plugin_dependency_notice() {
 	if ( ! array_key_exists( $filepath, get_plugins() ) ) {
 		$slug    = 'amp';
 		$path    = 'update.php';
-		$button  = __( 'Install', 'ampconf' );
+		$button  = __( 'Install', 'default' );
 		$message = __( 'The AMPConf theme requires the AMP plugin to be installed to function properly.', 'ampconf' );
 		$params  = array(
 			'action'   => 'install-plugin',
@@ -32,7 +32,7 @@ function ampconf_plugin_dependency_notice() {
 		);
 	} elseif ( ! is_plugin_active( $filepath ) ) {
 		$path    = 'plugins.php';
-		$button  = __( 'Activate', 'ampconf' );
+		$button  = __( 'Activate', 'default' );
 		$message = __( 'The AMPConf theme requires the AMP plugin to be activated to function properly.', 'ampconf' );
 		$params  = array(
 			'action'   => 'activate',
@@ -41,7 +41,7 @@ function ampconf_plugin_dependency_notice() {
 		);
 	} elseif ( isset( $updates->response[ $filepath ]->new_version ) ) {
 		$path    = 'update.php';
-		$button  = __( 'Update', 'ampconf' );
+		$button  = __( 'Update', 'default' );
 		$message = __( 'A new version of the AMP plugin is available, please upgrade.', 'ampconf' );
 		$params  = array(
 			'action'   => 'upgrade-plugin',

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -33,7 +33,7 @@
 		 Multiple valid text domains can be provided as a comma-delimited list. -->
 	<rule ref="WordPress.WP.I18n">
 		<properties>
-			<property name="text_domain" type="array" value="ampconf" />
+			<property name="text_domain" type="array" value="ampconf,default" />
 		</properties>
 	</rule>
 


### PR DESCRIPTION
This PR add the AMP plugin dependency notice and logic to install, activate and update. [Refer to the ACs](https://github.com/xwp/ampconf/issues/11#issue-286016135) for more info...

Closes #11 