### PR TITLE
Change the notices for when the plugin isn't installed or active

### DIFF
--- a/inc/plugin-dependency.php
+++ b/inc/plugin-dependency.php
@@ -24,7 +24,7 @@ function ampconf_plugin_dependency_notice() {
 		$slug    = 'amp';
 		$path    = 'update.php';
 		$button  = __( 'Install', 'default' );
-		$message = __( 'The AMPConf theme requires the AMP plugin to be installed to function properly.', 'ampconf' );
+		$message = __( 'The AMPConf theme requires the AMP plugin to be installed to render fully valid AMP. But it will still function without it.', 'ampconf' );
 		$params  = array(
 			'action'   => 'install-plugin',
 			'plugin'   => $slug,
@@ -33,7 +33,7 @@ function ampconf_plugin_dependency_notice() {
 	} elseif ( ! is_plugin_active( $filepath ) ) {
 		$path    = 'plugins.php';
 		$button  = __( 'Activate', 'default' );
-		$message = __( 'The AMPConf theme requires the AMP plugin to be activated to function properly.', 'ampconf' );
+		$message = __( 'The AMPConf theme requires the AMP plugin to be activated to render fully valid AMP. But it will still function without it.', 'ampconf' );
 		$params  = array(
 			'action'   => 'activate',
 			'plugin'   => $filepath,


### PR DESCRIPTION
**Request For Code Review**

Hi @westonruter or @ThierryA,
Could you please review this pull request? Alberto mentioned in our sync that it would be good if the plugin install/activate prompt didn't make it seem like the plugin was required for the theme to function.

So I removed 'function properly' from the message, and added another sentence:

<img width="993" alt="proposed-message" src="https://user-images.githubusercontent.com/4063887/35414064-02d299f0-01e7-11e8-9ba8-3255bd6c2afa.png">

This message could still use feedback. If you approve of this PR, we could send this PR to Alberto for approval.