### PR TITLE
Remove erroneous paragraphs wrapping the_content

### DIFF
--- a/templates/entry/full.php
+++ b/templates/entry/full.php
@@ -21,7 +21,7 @@
 	</header><!-- .entry__header -->
 
 	<div class="entry__content">
-		<p><?php the_content(); ?></p>
+		<?php the_content(); ?>
 	</div><!-- .entry__summary -->
 
 	<footer class="entry__footer">


### PR DESCRIPTION
The `wpautop` filter is already applying, so this results in a `<p>` erroneously (attempting) to wrap other `<p>` elements.